### PR TITLE
feat: add new deployment utilities

### DIFF
--- a/argocd-environment-prep-v1/action.yaml
+++ b/argocd-environment-prep-v1/action.yaml
@@ -26,9 +26,6 @@ inputs:
     description: 'Whether this is manually triggered'
 
 outputs:
-  k8s_target_environment:
-    description: 'Processed K8s target environment'
-    value: ${{ steps.prep_env.outputs.k8s_target_environment }}
   pr_branch_name_suffix:
     description: 'Processed PR branch name suffix'
     value: ${{ steps.prep_env.outputs.pr_branch_name_suffix }}

--- a/argocd-environment-prep-v1/action.yaml
+++ b/argocd-environment-prep-v1/action.yaml
@@ -41,7 +41,7 @@ runs:
   steps:
     - id: short_commit_id
       shell: bash
-      run: echo "short_commit_id=$(echo $GITHUB_SHA | cut -c1-7)" >> $GIT_OUTPUT
+      run: echo "short_commit_id=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
 
     - id: prep_env
       shell: bash

--- a/argocd-environment-prep-v1/action.yaml
+++ b/argocd-environment-prep-v1/action.yaml
@@ -1,0 +1,64 @@
+# Version: v1
+# Description: A composite GitHub Action that processes environment variables and 
+#              prepares Kubernetes paths for ArgoCD deployments.
+#
+# This action:
+# - Converts environment strings (e.g. "production:testnet:dukong") to filesystem paths
+# - Generates PR branch name suffixes from environment strings
+# - Constructs full Kubernetes file paths for updates
+
+name: 'ArgoCD Environment Preparation'
+description: 'Prepares environment variables and Kubernetes paths for ArgoCD deployments'
+
+inputs:
+  deployment_environment:
+    required: true
+    description: 'Deployment environment string (e.g. production:testnet:dukong)'
+  k8s_folder_path:
+    required: true
+    description: 'Base K8s folder path'
+  files_to_update_subpaths:
+    required: true
+    description: 'Comma-separated list of files to update'
+  manual_trigger:
+    required: false
+    default: 'false'
+    description: 'Whether this is manually triggered'
+
+outputs:
+  k8s_target_environment:
+    description: 'Processed K8s target environment'
+    value: ${{ steps.prep_env.outputs.k8s_target_environment }}
+  pr_branch_name_suffix:
+    description: 'Processed PR branch name suffix'
+    value: ${{ steps.prep_env.outputs.pr_branch_name_suffix }}
+  k8s_target_full_paths:
+    description: 'Full paths for K8s files'
+    value: ${{ steps.k8s_paths.outputs.k8s_target_full_paths }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: prep_env
+      shell: bash
+      run: |
+        TARGET_ENV_TEMP=$(echo "${{ inputs.deployment_environment }}" | tr ':' '/')
+        echo "k8s_target_environment=$TARGET_ENV_TEMP" >> $GITHUB_OUTPUT
+        
+        PR_BRANCH_NAME_SUFFIX_TEMP=$(echo "${{ inputs.deployment_environment }}" | tr ':' '-')
+        echo "pr_branch_name_suffix=$PR_BRANCH_NAME_SUFFIX_TEMP" >> $GITHUB_OUTPUT
+
+    - id: k8s_paths
+      shell: bash
+      run: |
+        if [[ "${{ inputs.files_to_update_subpaths }}" == *,* ]]; then
+          IFS=',' read -ra paths <<< "${{ inputs.files_to_update_subpaths }}"
+          full_paths=()
+          for path in "${paths[@]}"; do
+            full_paths+=("${{ inputs.k8s_folder_path }}/${{ steps.prep_env.outputs.k8s_target_environment }}/${path}")
+          done
+          echo "k8s_target_full_paths=${full_paths[*]}" >> $GITHUB_OUTPUT
+        else
+          full_path="${{ inputs.k8s_folder_path }}/${{ steps.prep_env.outputs.k8s_target_environment }}/${{ inputs.files_to_update_subpaths }}"
+          echo "k8s_target_full_paths=${full_path}" >> $GITHUB_OUTPUT
+        fi

--- a/argocd-environment-prep-v1/action.yaml
+++ b/argocd-environment-prep-v1/action.yaml
@@ -32,10 +32,17 @@ outputs:
   k8s_target_full_paths:
     description: 'Full paths for K8s files'
     value: ${{ steps.k8s_paths.outputs.k8s_target_full_paths }}
+  short_commit_id:
+    description: 'Short commit ID'
+    value: ${{ steps.short_commit_id.outputs.short_commit_id }}
 
 runs:
   using: "composite"
   steps:
+    - id: short_commit_id
+      shell: bash
+      run: echo "short_commit_id=$(echo $GITHUB_SHA | cut -c1-7)" >> $GIT_OUTPUT
+
     - id: prep_env
       shell: bash
       run: |

--- a/k8s-yaml-updater-v1/action.yaml
+++ b/k8s-yaml-updater-v1/action.yaml
@@ -1,4 +1,14 @@
-# Notes: need to have checkout in the job, so it can read all the files
+# GitHub Action to update YAML files using yq for Kubernetes/ArgoCD GitOps deployments
+# 
+# This action allows updating specific yaml paths with new values, typically used to:
+# - Update container image tags in k8s manifests
+# - Modify environment variables or config values
+# - Change resource specifications
+#
+# Prerequisites:
+# - yq must be installed in the runner
+# - Git checkout must be done before this action
+# - Write permissions required for git operations
 
 name: Prepare Deployment Repository
 description: Update yaml files with new values using yq

--- a/k8s-yaml-updater-v1/action.yaml
+++ b/k8s-yaml-updater-v1/action.yaml
@@ -1,0 +1,31 @@
+name: Prepare Deployment Repository
+description: Update yaml files with new values using yq
+inputs:
+  k8s_target_full_paths:
+    description: Target Path/File within the k8s repo to parse and commit tag updates
+    required: true
+  k8s_yq_paths:
+    description: Comma-separated string list of yq yaml paths to update
+    required: true
+  update_value:
+    description: Full value that should be updated in place for ArgoCD gitops
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Update YAML files
+      shell: bash
+      run: |
+        set -x
+        read -ra target_paths <<< "${{ inputs.k8s_target_full_paths }}"
+        for target_path in ${target_paths[@]}
+          do
+            if [ ! -f "${target_path//,}" ]; then echo "${target_path//,} not found; exit code 1" && exit 1; fi
+            read -ra update_paths <<< "${{ inputs.k8s_yq_paths }}"
+            for update_path in ${update_paths[@]}
+              do
+                yq --inplace "${update_path} = \"${{inputs.update_value}}\"" "${target_path}"
+              done
+          done
+        git diff

--- a/k8s-yaml-updater-v1/action.yaml
+++ b/k8s-yaml-updater-v1/action.yaml
@@ -14,6 +14,7 @@ inputs:
 runs:
   using: composite
   steps:
+    - uses: actions/checkout@v4
     - name: Update YAML files
       shell: bash
       run: |

--- a/k8s-yaml-updater-v1/action.yaml
+++ b/k8s-yaml-updater-v1/action.yaml
@@ -1,3 +1,5 @@
+# Notes: need to have checkout in the job, so it can read all the files
+
 name: Prepare Deployment Repository
 description: Update yaml files with new values using yq
 inputs:
@@ -14,7 +16,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
     - name: Update YAML files
       shell: bash
       run: |

--- a/yaml-updater-pr-v2/action.yaml
+++ b/yaml-updater-pr-v2/action.yaml
@@ -47,7 +47,8 @@ runs:
   steps:
   - uses: actions/checkout@v4
 
-  - uses: mantra-chain-tech/infra-github-actions-mantrachain/k8s-yaml-updater-v1@new-deployment-utilities
+  - name: Prepare Deployment Repository
+    uses: mantra-chain-tech/infra-github-actions-mantrachain/k8s-yaml-updater-v1@new-deployment-utilities
     with:
       k8s_target_full_paths: ${{ inputs.k8s_target_full_paths }}
       k8s_yq_paths: ${{ inputs.k8s_yq_paths }}

--- a/yaml-updater-pr-v2/action.yaml
+++ b/yaml-updater-pr-v2/action.yaml
@@ -1,0 +1,67 @@
+name: Yaml Updater - Create Pull Request
+description: Create a pull request to update a value in a yaml
+inputs:
+  git_host:
+    description: Git Repository Hostname
+    required: true
+    default: "github.com"
+  git_token:
+    description: Git Repository access token from the upstream repository
+    required: true
+  k8s_repo_target_branch:
+    description: Target branch we are updating a value in a yaml
+    default: main
+  k8s_target_full_paths:
+    description: Target Path/File within the k8s rpo to parse and commit tag updates
+    required: true
+  k8s_yq_paths:
+    description: Comma-separated string list of yq yaml paths to update.
+    required: true
+  update_value:
+    description: Full value that should be updated in place for ArgoCD gitops.
+    required: true
+  update_message:
+    description: Message to be used for GitOps commits on the relevant ArgoCD repo.
+    required: true
+  update_title:
+    description: Title of the PR
+    required: true
+  commit_message:
+    description: Title of the commit
+    required: true
+  pr_branch_name:
+    description: Name of the branch to create the PR
+    required: true
+  signoffs:
+    description: Signoffs
+    required: false
+    default: 'true'
+  reviewers:
+    description: Person to review the PR
+    required: false
+
+outputs: {}
+
+runs:
+  using: composite
+  steps:
+  - uses: actions/checkout@v4
+
+  - uses: mantra-chain-tech/infra-github-actions-mantrachain/k8s-yaml-updater-v1@new-deployment-utilities
+    with:
+      k8s_target_full_paths: ${{ inputs.k8s_target_full_paths }}
+      k8s_yq_paths: ${{ inputs.k8s_yq_paths }}
+      update_value: ${{ inputs.update_value }}
+
+  - name: Create Pull Request
+    uses: peter-evans/create-pull-request@v7
+    with:
+      signoff: ${{ inputs.signoffs}}
+      title: ${{ inputs.update_title }}
+      body: ${{ inputs.update_message }}
+      commit-message: ${{ inputs.commit_message }}
+      base: ${{ inputs.k8s_repo_target_branch }}
+      branch: ${{ inputs.pr_branch_name }}
+      token: ${{ inputs.git_token }}
+      author: "mantra-finance-bot <mantra-finance-bot@mantra.finance>"
+      reviewers: ${{ inputs.reviewers }}


### PR DESCRIPTION
- argocd-environment-prep-v1 --> transform the part that calculate the kubernetes paths based on our filestructure convention for the .k8s folder

- k8s-yaml-updater-v1 --> split the part that update the yaml in its own action, because admin needs to update the kustomization.yaml in two places, and in different format before performing the PR, so we can let some jobs update their k8s file the way they want to before calling the PR action.

- yaml-updater-pr-v2 --> call the new k8s yaml updater action. Can remove -v1 folder when we will have migrated Bridge to v2 later on